### PR TITLE
Using pipenv for python-test github workflow

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,28 +8,24 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.9
+    - name: Set up Python 3.7
       uses: actions/setup-python@v1
       with:
-        python-version: 3.9
+        python-version: 3.7
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pylint
-        pip install discord
-        pip install python-dotenv
-        pip install PyNaCl
-        pip install asyncio
-        pip install pytz
-        pip install pytest
-        pip install coverage
+        pip install pipenv
+    - name: Install pipenv dependencies
+      run: |
+        pipenv install --dev
     - name: Analysing the code with pylint
       run: |
         # Stop run if there are linting errors
-        pylint `find . \( -iname '*.py' \)`
+        pipenv run lint
     - name: Test with pytest with coverage
       run: |
-        coverage run -m pytest
-    - name: Publish coverage to html
+        pipenv run tests-cov
+    - name: Generate coverage report
       run: |
-        coverage report -m 
+        pipenv run cov-report

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 discord.log
 .vscode/
 .coverage
+*.code-workspace

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,9 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+pytest = "*"
+pylint = "*"
+coverage = "*"
 
 [packages]
 discord = "*"
@@ -15,3 +18,9 @@ pytz = "*"
 
 [requires]
 python_version = "3.7"
+
+[scripts]
+tests = "pytest"
+lint = "bash ./scripts/pylint-run.sh"
+tests-cov = "coverage run -m pytest"
+cov-report = "coverage report -m"

--- a/scripts/pylint-run.sh
+++ b/scripts/pylint-run.sh
@@ -1,0 +1,1 @@
+pylint `find $PWD -iname "*.py"`


### PR DESCRIPTION
Using pipenv for python-test github workflow rather than installing dependencies manually. Added dev dependencies to pipfile. Added scripts to pipfile to run tests, lint, and generate coverage report.